### PR TITLE
Fix/Unable to get the properties of URL class

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const www = new Proxy(new URL('https://www'), {
         if (typeof o === 'function') {
             return o.bind(target)
         }
-        if (typeof prop !== 'string') {
-            return o;
+        if (Reflect.has(target,prop)) {
+            return o
         }
         if (prop === 'then') {
             return Promise.prototype.then.bind(fetch(target));


### PR DESCRIPTION

![Capture](https://user-images.githubusercontent.com/15136948/109166202-67418600-77b7-11eb-8e4f-0cda2fe34540.PNG)


The above screen capture shows that the `www` Proxy was unable to retrieve the property of `URL`.

This PR is to fix the issue